### PR TITLE
Alternative GPU tracking implementation based on NVML

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -48,6 +48,7 @@ GIT_BRANCH           	:= master
 XALT_V               	:= src/xalt_version.h
 SYSLOG_MSG_SZ        	:= @SYSLOG_MSG_SZ@
 HAVE_DCGM         	:= @HAVE_DCGM@
+HAVE_NVML               := @HAVE_NVML@
 STATIC_LIBS             := @STATIC_LIBS@
 PRELOAD_ONLY            := @PRELOAD_ONLY@	
 CXX_LD_LIBRARY_PATH  	:= @CXX_LD_LIBRARY_PATH@
@@ -147,7 +148,7 @@ build_compiled: build_uuid
 	cd src;                                                                                    \
         $(MAKE) LD_PRELOAD= XALT_EXECUTABLE_TRACKING= PARENT_DIR=$(abs_srcdir) DESTDIR=$(DESTDIR)  \
                 LDFLAGS="$(LDFLAGS)" LIBEXEC=$(LIBEXEC) SBIN=$(SBIN) BIN=$(BIN)  LIB=$(LIB)        \
-                LIB64=$(LIB64) HAVE_32BIT=$(HAVE_32BIT) OPTLVL="$(OPTLVL)" HAVE_DCGM=$(HAVE_DCGM)  \
+                LIB64=$(LIB64) HAVE_32BIT=$(HAVE_32BIT) OPTLVL="$(OPTLVL)" HAVE_DCGM=$(HAVE_DCGM) HAVE_NVML=$(HAVE_NVML) \
                 XALT_FILE_PREFIX=$(XALT_FILE_PREFIX) STATIC_LIBS=$(STATIC_LIBS)                    \
                 MY_HOSTNAME_PARSER=$(MY_HOSTNAME_PARSER) all
 
@@ -230,6 +231,7 @@ __installMe:
 	        -e 's|@grep@|$(PATH_TO_GREP)|g'                            	  \
 	        -e 's|@have_working_libuuid@|$(HAVE_LIBUUID)|g'            	  \
 	        -e 's|@have_dcgm@|$(HAVE_DCGM)|g'                       	  \
+	        -e 's|@have_nvml@|$(HAVE_NVML)|g'                       	  \
 	        -e 's|@head@|$(PATH_TO_HEAD)|g'                            	  \
 	        -e 's|@ldd@|$(PATH_TO_LDD)|g'                              	  \
 	        -e 's|@logger@|$(PATH_TO_LOGGER)|g'                        	  \

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -91,6 +91,7 @@ echo "XALT_MPI_TRACKING...................................." : $XALT_MPI_TRACKIN
 echo "XALT_GPU_TRACKING...................................." : $XALT_GPU_TRACKING
 echo "XALT 32bit support..................................." : $HAVE_32BIT
 echo "XALT Using DCGM......................................" : $HAVE_DCGM
+echo "XALT Using NVML......................................" : $HAVE_NVML
 echo "XALT build with MySQL support........................" : $Using_MYSQL
 echo "XALT Compute SHA1 sum for libraries.................." : $COMPUTE_SHA1SUM
 echo "XALT CXX LD_LIBRARY_PATH............................." : $CXX_LD_LIBRARY_PATH

--- a/configure
+++ b/configure
@@ -627,6 +627,7 @@ XALT_GIT_VERSION
 VERSION
 PKGV
 HAVE_DCGM
+HAVE_NVML
 EGREP
 GREP
 CPP
@@ -705,7 +706,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -798,7 +798,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1051,15 +1050,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1197,7 +1187,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1350,7 +1340,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1383,7 +1372,8 @@ Optional Packages:
                           Track functions from modules [[yes]]
   --with-xaltFilePrefix=ans
                           Prefix where the json files are written [[$HOME]]
-  --with-trackGPU=ans     Track GPU executables, [[no]]
+  --with-trackGPU=ans     Track GPU executables {yes(nvml),no,dcgm,nvml},
+                          [[no]]
   --with-trackMPI=ans     Track MPI executables, [[yes]]
   --with-trackSPSR=ans    Track SPSR executables, [[yes]]
   --with-trackScalarPrgms=ans
@@ -5161,8 +5151,10 @@ fi
 
 
 
+HAVE_NVML=no
+
 HAVE_DCGM=no
-if test $XALT_GPU_TRACKING = yes; then
+if test $XALT_GPU_TRACKING = "dcgm" ; then
   ac_fn_c_check_header_mongrel "$LINENO" "dcgm_agent.h" "ac_cv_header_dcgm_agent_h" "$ac_includes_default"
 if test "x$ac_cv_header_dcgm_agent_h" = xyes; then :
 
@@ -5294,7 +5286,91 @@ else
 fi
 
   fi
+elif test $XALT_GPU_TRACKING = yes || test $XALT_GPU_TRACKING = "nvml" ; then
+  ac_fn_c_check_header_mongrel "$LINENO" "nvml.h" "ac_cv_header_nvml_h" "$ac_includes_default"
+if test "x$ac_cv_header_nvml_h" = xyes; then :
+
+$as_echo "#define HAVE_NVML_H 1" >>confdefs.h
+
+else
+  as_fn_error $? "Unable to include GPU tracking without NVML" "$LINENO" 5
 fi
+
+
+  ac_fn_c_check_header_mongrel "$LINENO" "dlfcn.h" "ac_cv_header_dlfcn_h" "$ac_includes_default"
+if test "x$ac_cv_header_dlfcn_h" = xyes; then :
+
+$as_echo "#define HAVE_DCFCN_H 1" >>confdefs.h
+
+else
+  as_fn_error $? "Unable to include GPU tracking without dlfcn.h" "$LINENO" 5
+fi
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
+$as_echo_n "checking for library containing dlopen... " >&6; }
+if ${ac_cv_search_dlopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char dlopen ();
+int
+main ()
+{
+return dlopen ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' dl dld; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_dlopen=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_dlopen+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_dlopen+:} false; then :
+
+else
+  ac_cv_search_dlopen=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dlopen" >&5
+$as_echo "$ac_cv_search_dlopen" >&6; }
+ac_res=$ac_cv_search_dlopen
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+  $as_echo "#define HAVE_DLOPEN 1" >>confdefs.h
+
+                  $as_echo "#define USE_NVML 1" >>confdefs.h
+
+                  HAVE_NVML=yes
+else
+  as_fn_error $? "Unable to find dlopen" "$LINENO" 5
+fi
+
+fi
+
 
 
 
@@ -7032,6 +7108,7 @@ echo "XALT_MPI_TRACKING...................................." : $XALT_MPI_TRACKIN
 echo "XALT_GPU_TRACKING...................................." : $XALT_GPU_TRACKING
 echo "XALT 32bit support..................................." : $HAVE_32BIT
 echo "XALT Using DCGM......................................" : $HAVE_DCGM
+echo "XALT Using NVML......................................" : $HAVE_NVML
 echo "XALT build with MySQL support........................" : $Using_MYSQL
 echo "XALT Compute SHA1 sum for libraries.................." : $COMPUTE_SHA1SUM
 echo "XALT CXX LD_LIBRARY_PATH............................." : $CXX_LD_LIBRARY_PATH

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_ARG_WITH(xaltFilePrefix,
 
 AC_SUBST(XALT_GPU_TRACKING)
 AC_ARG_WITH(trackGPU,
-    AC_HELP_STRING([--with-trackGPU=ans],[Track GPU executables, [[no]]]),
+    AC_HELP_STRING([--with-trackGPU=ans],[Track GPU executables {yes(nvml),no,dcgm,nvml}, [[no]]]),
     XALT_GPU_TRACKING="$withval"
     AC_MSG_RESULT([XALT_GPU_TRACKING=$with_trackGPU])
     AC_DEFINE_UNQUOTED(XALT_GPU_TRACKING, "$with_trackGPU")dnl
@@ -331,9 +331,11 @@ if test -z "$PATH_TO_FLEX" ; then
 fi
 
 
+AC_SUBST(HAVE_NVML)
+HAVE_NVML=no
 AC_SUBST(HAVE_DCGM)
 HAVE_DCGM=no
-if test $XALT_GPU_TRACKING = yes; then
+if test $XALT_GPU_TRACKING = "dcgm" ; then
   AC_CHECK_HEADER(dcgm_agent.h,
                   [AC_DEFINE([HAVE_DCGM_AGENT_H], 1,
                      [Define to 1 if you have DCGM.])],
@@ -343,7 +345,22 @@ if test $XALT_GPU_TRACKING = yes; then
   else
     AC_SEARCH_LIBS([dcgmInit], [dcgm], [AC_DEFINE(USE_DCGM, [1]) HAVE_DCGM=yes], [AC_MSG_ERROR([Unable to include GPU tracking without DCGM])])
   fi
+elif test $XALT_GPU_TRACKING = yes || test $XALT_GPU_TRACKING = "nvml" ; then
+  AC_CHECK_HEADER(nvml.h,
+                  [AC_DEFINE([HAVE_NVML_H], 1,
+                     [Define to 1 if you have NVML.])],
+                  [AC_MSG_ERROR([Unable to include GPU tracking without NVML])])
+  AC_CHECK_HEADER(dlfcn.h,
+                  [AC_DEFINE([HAVE_DCFCN_H], 1,
+                     [Define to 1 if you have dlfcn.h.])],
+                  [AC_MSG_ERROR([Unable to include GPU tracking without dlfcn.h])])
+  AC_SEARCH_LIBS([dlopen], [dl dld],
+                 [AC_DEFINE([HAVE_DLOPEN], [1])
+                  AC_DEFINE([USE_NVML], [1])
+                  HAVE_NVML=yes],
+                 [AC_MSG_ERROR([Unable to find dlopen])])
 fi
+
 AC_SUBST(PKGV)
 AC_SUBST(VERSION)
 AC_SUBST(XALT_GIT_VERSION)

--- a/docs/source/020_site_configuration.rst
+++ b/docs/source/020_site_configuration.rst
@@ -196,9 +196,7 @@ want to track MPI programs you can do::
 Track GPU usage
 ^^^^^^^^^^^^^^^
 
-Optionally, XALT can track NVIDIA GPU usage. You will need the DCGM
-library from NVIDIA for this to work.  DCGM is free to download from
-https://developer.nvidia.com/data-center-gpu-manager-dcgm.
+Optionally, XALT can track NVIDIA GPU usage.
 
 You can tell XALT to track GPU usage by configuring it with::
 

--- a/docs/source/040_install_and_test.rst
+++ b/docs/source/040_install_and_test.rst
@@ -46,12 +46,19 @@ package.  The first one is a Lua modulefile that can be used with Lmod::
 
   setenv("XALT_EXECUTABLE_TRACKING",       "yes")
 
+  # Uncomment this to track GPU usage
+  #setenv("XALT_GPU_TRACKING",              "yes")
+
   local base  = "/opt/apps/xalt/xalt"  --> Change to match your site!!!
   local bin   = pathJoin(base,"bin")
 
   prepend_path{"PATH",          bin, priority="100"}
   prepend_path("LD_PRELOAD",    pathJoin(base,"$LIB/libxalt_init.so"))
   prepend_path("COMPILER_PATH", bin)
+
+  # Uncomment this to use XALT inside Singularity containers
+  #setenv("SINGULARITYENV_LD_PRELOAD", pathJoin(base,"$LIB/libxalt_init.so"))
+  #prepend_path("SINGULARITY_BINDPATH", base)
 
   ------------------------------------------------------------
   -- Only set this in production not for testing!!!
@@ -61,9 +68,16 @@ The following is a TCL modulefile::
 
   setenv XALT_EXECUTABLE_TRACKING       yes
 
+  # Uncomment this to track GPU usage
+  #setenv XALT_GPU_TRACKING              yes
+
   prepend-path  PATH            /opt/apps/xalt/xalt/bin  100
   prepend-path  LD_PRELOAD      /opt/apps/xalt/xalt/\$LIB/libxalt_init.so
   prepend-path  COMPILER_PATH   /opt/apps/xalt/xalt/bin
+
+  # Uncomment this to use XALT inside Singularity containers
+  #setenv SINGULARITYENV_LD_PRELOAD /opt/apps/xalt/xalt/\$LIB/libxalt_init.so
+  #prepend-path  SINGULARITY_BINDPATH   /opt/apps/xalt/xalt
 
   ############################################################
   ## Only set this is production not for testing!!!
@@ -72,6 +86,9 @@ The following is a TCL modulefile::
 
 Obviously, these modulefiles will need to be modified to match your
 site's location of XALT.
+
+  **Note**: To track GPU usage, XALT must also be configured with
+  --with-trackGPU=yes.
 
   **Note**: If your site do NOT use Lmod, then make sure that XALT's ld is
   always found before the regular ld

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -9,6 +9,9 @@ ifeq ($(HAVE_DCGM),yes)
     LIBDCGM:=-ldcgm
   endif
 endif
+ifeq ($(HAVE_NVML),yes)
+  LIBNVML:=-ldl
+endif
 ifeq ($(STATIC_LIBS),yes)
   LIBCRYPTO:=-l:libcrypto.a -ldl -lz
 else
@@ -350,7 +353,7 @@ $(DESTDIR)$(LIB64)/libxalt_init.so: $(DESTDIR)$(LIB64)/xalt_initialize_preload.o
                                     $(DESTDIR)$(LIB64)/base64.o                  \
                                     $(MY_HOSTNAME_PARSER_OBJ)                    \
                                     $(DESTDIR)$(LIB64)/xalt_fgets_alloc.o
-	$(LINK.c) $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) $(LDFLAGS) -L$(DESTDIR)$(LIB64) -o $@  $^ -l:libuuid.a $(LIBDCGM)
+	$(LINK.c) $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) $(LDFLAGS) -L$(DESTDIR)$(LIB64) -o $@  $^ -l:libuuid.a $(LIBDCGM) $(LIBNVML)
 
 neat:
 	$(RM) *~

--- a/src/xalt_header.h.in
+++ b/src/xalt_header.h.in
@@ -4,6 +4,7 @@
 #ifndef IN_32_BIT_MODE
 /* Define if you have DCGM support */
 #undef USE_DCGM
+#undef USE_NVML
 
 #endif
 

--- a/src/xalt_initialize.c
+++ b/src/xalt_initialize.c
@@ -53,8 +53,18 @@
 #include "xalt_hostname_parser.h"
 #include "build_uuid.h"
 
+#if USE_DCGM && USE_NVML
+#error "Both DCGM and NVML enabled.  This is not allowed."
+#endif
+
+#ifdef USE_NVML
+/* This code will only ever be active in 64 bit mode and not 32 bit mode */
+#include <dlfcn.h>
+#include <nvml.h>
+#endif
+
 #ifdef USE_DCGM
-/* This code will only every be active in 64 bit mode and not 32 bit mode*/
+/* This code will only ever be active in 64 bit mode and not 32 bit mode */
 #  include <dcgm_agent.h>
 #  include <dcgm_structs.h>
 #endif
@@ -125,6 +135,9 @@ static void            abspath(char * path, int sz);
 static volatile double epoch();
 static unsigned int    mix(unsigned int a, unsigned int b, unsigned int c); 
 static double          scalar_program_sample_probability(double runtime);
+#ifdef USE_NVML
+static int             load_nvml();
+#endif
 
 void myinit(int argc, char **argv);
 void myfini();
@@ -158,6 +171,26 @@ static char *       pathArg	          = NULL;
 static char *       ldLibPathArg          = NULL;
 static int          num_gpus              = 0;
 static int          b64_len               = 0;
+#ifdef USE_NVML
+static unsigned long long __time          = 0;
+static void * nvml_handle                 = NULL;
+static nvmlReturn_t (*_nvmlDeviceGetAccountingBufferSize)(nvmlDevice_t,
+                                                          unsigned int *);
+static nvmlReturn_t (*_nvmlDeviceGetAccountingMode)(nvmlDevice_t,
+                                                    nvmlEnableState_t *);
+static nvmlReturn_t (*_nvmlDeviceGetAccountingPids)(nvmlDevice_t,
+                                                    unsigned int *,
+                                                    unsigned int *);
+static nvmlReturn_t (*_nvmlDeviceGetAccountingStats)(nvmlDevice_t,
+                                                     unsigned int,
+                                                     nvmlAccountingStats_t *);
+static nvmlReturn_t (*_nvmlDeviceGetCount)(unsigned int *);
+static nvmlReturn_t (*_nvmlDeviceGetHandleByIndex)(unsigned int,
+                                                   nvmlDevice_t *);
+static char * (*_nvmlErrorString)(nvmlReturn_t);
+static nvmlReturn_t (*_nvmlInit)();
+static nvmlReturn_t (*_nvmlShutdown)();
+#endif
 #ifdef USE_DCGM
 static dcgmHandle_t dcgm_handle           = NULL;
 /* This code will only every be active in 64 bit mode and not 32 bit mode*/
@@ -467,8 +500,8 @@ void myinit(int argc, char **argv)
 
   build_uuid(uuid_str);
 
-#ifdef USE_DCGM
-  /* This code will only every be active in 64 bit mode and not 32 bit mode*/
+#if USE_DCGM || USE_NVML
+  /* This code will only ever be active in 64 bit mode and not 32 bit mode */
   v  = getenv("XALT_GPU_TRACKING");
   if (v == NULL)
     v = XALT_GPU_TRACKING;
@@ -479,6 +512,34 @@ void myinit(int argc, char **argv)
       if (xalt_gpu_tracking)
         {
           DEBUG0(stderr, "  GPU tracing\n");
+
+#ifdef USE_NVML
+          /* Open the NVML library at runtime.  This avoids failing if
+             the library is not available on a particular system.  In
+             that case, the handle will not be created and GPU
+             tracking will be disabled. */
+          if (load_nvml() == 0) {
+            xalt_gpu_tracking = 0;
+            break;
+          }
+
+          nvmlReturn_t result;
+          struct timeval tv;
+
+          /* Mark time the program started.  Use this to compare to
+           * GPU process timestamps in fini to only count processes
+           * that started during the lifetime of the program. */
+          gettimeofday(&tv, NULL);
+          __time = (unsigned long long)(tv.tv_sec) * 1000000 + (unsigned long long)(tv.tv_usec);
+
+          result = _nvmlInit();
+          if (result != NVML_SUCCESS)
+            {
+              DEBUG1(stderr, "    -> Stopping GPU Tracking => Cannot initialize NVML: %s\n\n", _nvmlErrorString(result));
+              xalt_gpu_tracking = 0;
+              break;
+            }
+#elif USE_DCGM
           dcgmReturn_t result;
 
           result = dcgmInit();
@@ -528,6 +589,7 @@ void myinit(int argc, char **argv)
               dcgm_handle       = NULL;
               break;
             }
+#endif
         }
     }
   while(0);
@@ -718,37 +780,160 @@ void myfini()
   end_time = epoch();
   unsetenv("LD_PRELOAD");
 
-#ifdef USE_DCGM
-  /* This code will only ever be active in 64 bit mode and not 32 bit mode*/
-  if (xalt_gpu_tracking && dcgm_handle != NULL)
+#if USE_DCGM || USE_NVML
+  /* This code will only ever be active in 64 bit mode and not 32 bit mode */
+  if (xalt_gpu_tracking)
     {
-      /* Collect DCGM job stats */
-      dcgmReturn_t result;
-      dcgmJobInfo_t job_info;
+#ifdef USE_NVML
+      nvmlReturn_t result;
+      unsigned int device_count = 0;
 
-      DEBUG0(my_stderr, "  GPU tracing\n");
+      /* Get the number of GPU devices in the system */
+      result = _nvmlDeviceGetCount(&device_count);
+      if (result == NVML_SUCCESS)
+        {
+          DEBUG1(my_stderr, "  %d GPUs detected\n", device_count);
 
-      dcgmUpdateAllFields(dcgm_handle, 1);
-      dcgmJobStopStats(dcgm_handle, uuid_str);
+          /* Loop over GPU devices */
+          unsigned int i = 0;
+          for (i = 0 ; i < device_count ; i++)
+            {
+              nvmlDevice_t device;
+              nvmlEnableState_t mode;
+              unsigned int pid_count = 0, max_pid_count = 0;
+              unsigned int *pids = 0;
+              unsigned int num_active_pids = 0;
 
-      job_info.version = dcgmJobInfo_version2;
-      result = dcgmJobGetStats(dcgm_handle, uuid_str, &job_info);
-      if (result == DCGM_ST_OK)
-	{
-	  int i = 0;
-	  DEBUG1(my_stderr, "  %d GPUs detected\n", job_info.numGpus);
-	  for (i = 0 ; i < job_info.numGpus ; i++)
-	    {
-	      DEBUG2(my_stderr, "  GPU %d: num compute pids %d\n", i, job_info.gpus[i].numComputePids);
-	      if (job_info.gpus[i].numComputePids > 0)
-		num_gpus++;
-	    }
-	  DEBUG2(my_stderr, "  %d of %d GPUs were used\n", num_gpus, job_info.numGpus);
-	}
+              /* Get a device handle */
+              result = _nvmlDeviceGetHandleByIndex(i, &device);
+              if (result != NVML_SUCCESS)
+                {
+                  DEBUG2(my_stderr, "  Unable to get device handle for GPU %d: %s\n", i, _nvmlErrorString(result));
+                  continue;
+                }
 
-      dcgmJobRemove(dcgm_handle, uuid_str);
-      dcgmStopEmbedded(dcgm_handle);
-      dcgmShutdown();
+              /* Check whether accounting mode is enabled for this device */
+              result = _nvmlDeviceGetAccountingMode(device, &mode);
+              if (result != NVML_SUCCESS)
+                {
+                  DEBUG2(my_stderr, "  Unable to get accounting mode for GPU %d: %s\n", i, _nvmlErrorString(result));
+                  continue;
+                }
+              if (mode != NVML_FEATURE_ENABLED)
+                {
+                  DEBUG2(my_stderr, "  Accounting mode is not enabled for GPU %d. Enable accounting mode: sudo nvidia-smi -i %d -am 1\n", i, i);
+                  continue;
+                }
+
+              /* Get the size of the accounting buffer */
+              result = _nvmlDeviceGetAccountingBufferSize(device, &max_pid_count);
+              if (result != NVML_SUCCESS)
+                {
+                  DEBUG2(my_stderr, "  Unable to get the accounting buffer size for GPU %d: %s\n", i, _nvmlErrorString(result));
+                  continue;
+                }
+
+              /* Allocate space for the accounting data */
+              pids = (unsigned int *)malloc(sizeof(unsigned int)*max_pid_count);
+              memset(pids, 0, sizeof(unsigned int)*max_pid_count);
+
+              /* Get PID accounting data */
+              pid_count = max_pid_count;
+              result = _nvmlDeviceGetAccountingPids(device, &pid_count, pids);
+              if (result != NVML_SUCCESS)
+                {
+                  DEBUG2(my_stderr, "  Unable to get accounting data for GPU %d: %s\n", i, _nvmlErrorString(result));
+                  free(pids);
+                  continue;
+                }
+
+              /* Loop over the PID accounting data looking for PIDs that
+               * started after the program. Count those as belonging to
+               * this program execution. */
+              unsigned int j = 0;
+              for (j = 0 ; j < pid_count ; j++)
+                {
+                  nvmlAccountingStats_t stats;
+
+                  result = _nvmlDeviceGetAccountingStats(device, pids[j], &stats);
+                  if (result == NVML_SUCCESS)
+                    {
+                      /* If the GPU PID start time is later than the
+                         program start time, consider the GPU PID to
+                         belong to the program.  This would not
+                         necessarily be true if the system is
+                         shared by unrelated programs. */
+                      if (stats.startTime >= __time)
+                        {
+                          /* There is a mystery PID that appears for all
+                             GPUs.  The PID is constant and is assumed
+                             to be a CUDA cleanup process.  That PID
+                             has a maxMemoryUsage of 0 while a real
+                             PID will always have a non-zero value, so
+                             use that to exclude it. */
+                          if (stats.maxMemoryUsage > 0)
+                            {
+                              num_active_pids++;
+                              DEBUG4(my_stderr, "  PID %d startTime=%llu time=%llu isRunning=%d\n", pids[j], stats.startTime, stats.time, stats.isRunning);
+                            }
+                        }
+                      /* Note that the GPU compute process has not
+                         terminated yet.  Therefore stats.isRunning ==
+                         1, and stats.time == 0, so it is not possible
+                         to get the amount of time the GPU device was
+                         actually in use. */
+                    }
+                }
+
+              free(pids);
+
+              DEBUG2(my_stderr, "  GPU %d: num compute pids %d\n", i, num_active_pids);
+
+              if (num_active_pids > 0) {
+                num_gpus++;
+              }
+            }
+
+          /* Cleanup */
+          result = _nvmlShutdown();
+          if (result != NVML_SUCCESS)
+            {
+              DEBUG1(my_stderr, "  Error shutting down NVML: %s\n", _nvmlErrorString(result));
+            }
+          dlclose(nvml_handle);
+        }
+#elif USE_DCGM
+      if (dcgm_handle != NULL)
+        {
+          /* Collect DCGM job stats */
+          dcgmReturn_t result;
+          dcgmJobInfo_t job_info;
+
+          DEBUG0(my_stderr, "  GPU tracing\n");
+
+          dcgmUpdateAllFields(dcgm_handle, 1);
+          dcgmJobStopStats(dcgm_handle, uuid_str);
+
+          job_info.version = dcgmJobInfo_version2;
+          result = dcgmJobGetStats(dcgm_handle, uuid_str, &job_info);
+          if (result == DCGM_ST_OK)
+            {
+              int i = 0;
+              DEBUG1(my_stderr, "  %d GPUs detected\n", job_info.numGpus);
+              for (i = 0 ; i < job_info.numGpus ; i++)
+                {
+                  DEBUG2(my_stderr, "  GPU %d: num compute pids %d\n", i, job_info.gpus[i].numComputePids);
+                  if (job_info.gpus[i].numComputePids > 0)
+                    num_gpus++;
+                }
+              DEBUG2(my_stderr, "  %d of %d GPUs were used\n", num_gpus, job_info.numGpus);
+            }
+
+          dcgmJobRemove(dcgm_handle, uuid_str);
+          dcgmStopEmbedded(dcgm_handle);
+          dcgmShutdown();
+        }
+#endif
     }
 #endif
 
@@ -823,6 +1008,38 @@ void myfini()
     }
 }
 
+#ifdef USE_NVML
+static int load_nvml()
+{
+  /* Open the NVML library.  Let the dynamic loader find it (do not
+     specify a path). */
+  nvml_handle = dlopen("libnvidia-ml.so", RTLD_LAZY);
+  if (! nvml_handle)
+    {
+      DEBUG1(stderr, "    -> Unable to open libnvidia-ml.so: %s\n\n",
+             dlerror());
+      return 0;
+    }
+
+  /* Load symbols */
+  *(void**)(&_nvmlDeviceGetAccountingBufferSize) =
+    dlsym(nvml_handle, "nvmlDeviceGetAccountingBufferSize");
+  *(void**)(&_nvmlDeviceGetAccountingMode) =
+    dlsym(nvml_handle, "nvmlDeviceGetAccountingMode");
+  *(void**)(&_nvmlDeviceGetAccountingPids) =
+    dlsym(nvml_handle, "nvmlDeviceGetAccountingPids");
+  *(void**)(&_nvmlDeviceGetAccountingStats) =
+    dlsym(nvml_handle, "nvmlDeviceGetAccountingStats");
+  *(void**)(&_nvmlDeviceGetCount) = dlsym(nvml_handle, "nvmlDeviceGetCount");
+  *(void**)(&_nvmlDeviceGetHandleByIndex) =
+    dlsym(nvml_handle, "nvmlDeviceGetHandleByIndex");
+  *(void**)(&_nvmlErrorString) = dlsym(nvml_handle, "nvmlErrorString");
+  *(void**)(&_nvmlInit) = dlsym(nvml_handle, "nvmlInit");
+  *(void**)(&_nvmlShutdown) = dlsym(nvml_handle, "nvmlShutdown");
+
+  return 1;
+}
+#endif
 
 static long compute_value(const char **envA)
 {


### PR DESCRIPTION
The current GPU tracking implementation is based on DCGM, a free tool from NVIDIA.

DCGM is a high level library, and as such, has dependencies on other libraries such as `libstdc++`.  I have observed a few very rare corner cases related to `libstc++` incompatibilities.  While limited to very specific situations, it is not zero.  Since XALT uses LD_PRELOAD, any issue manifests to the user as a failure to run their application, which is unacceptable.

This PR re-implements GPU tracking using NVML.  NVML is a lower level library than DCGM; in fact, DCGM uses NVML.  

Advantages of this implementation:

1. NVML is distributed with the Nvidia driver, so no need for a separate download.

2. The NVML library, `libnvidia-ml.so`, is dynamically loaded at runtime via`dlopen()` rather than at XALT link time.  As a result, if `libnvidia-ml.so` is not available on a system, GPU tracking is silently and automatically disabled (as opposed to a `error while loading shared libraries` runtime linker error).

3. Being lower level, NVML does not introduce dependencies such as `libstdc++.so`.  This is also advantageous when using XALT in Singularity containers.

The `--with-trackGPU` configure option now accepts `yes`, `nvml`, and `dcgm`.  `dcgm` continues to provide the previous GPU tracking functionality, unchanged.  `nvml` provides the new functionality contained in this PR.  `yes` is equivalent to `nvml`.

Also adds documentation for using XALT with Singularity containers.

FYI: @treydock 