### PR TITLE
Fix missing files in compilation list

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -46,11 +46,11 @@ endif
 
 LIB_OPTIONS := -fPIC -shared
 
-WARN_FLAGS  := -Wall -Wno-unused-result 
-CF_INIT     := -I. -fPIC 
-COMMON_FLGS := $(OPTLVL) $(WARN_FLAGS)  -I__build__ -I$(THIS_DIR) 
+WARN_FLAGS  := -Wall -Wno-unused-result
+CF_INIT     := -I. -fPIC
+COMMON_FLGS := $(OPTLVL) $(WARN_FLAGS)  -I__build__ -I$(THIS_DIR)
 CXXFLAGS    := $(COMMON_FLGS) -std=c++11 $(USE_PREFIX)
-CFLAGS      := $(COMMON_FLGS) $(HAVE_EXTERNAL_HOSTNAME_PARSER) 
+CFLAGS      := $(COMMON_FLGS) $(HAVE_EXTERNAL_HOSTNAME_PARSER)
 
 C_SRC       :=                             \
 	       $(HOST_PARSER_SRC)          \
@@ -128,7 +128,7 @@ XEL_OBJS     := $(patsubst %.C, %.o, $(XEL_CXX_SRC)) $(patsubst %.c, %.o, $(XEL_
 
 XSL_EXEC     := $(DESTDIR)$(LIBEXEC)/xalt_strip_linklib
 XSL_CXX_SRC  := xalt_strip_linklib.C parseJsonStr.C buildRmapT.C xalt_utils.C epoch.C
-XSL_C_SRC    := jsmn.c  xalt_fgets_alloc.c xalt_quotestring.c 
+XSL_C_SRC    := jsmn.c  xalt_fgets_alloc.c xalt_quotestring.c
 XSL_OBJS     := $(patsubst %.C, %.o, $(XSL_CXX_SRC)) $(patsubst %.c, %.o, $(XSL_C_SRC))
 
 F2DB_EXEC    := $(DESTDIR)$(SBIN)/xalt_file_to_db
@@ -148,7 +148,7 @@ S2DB_OBJS    := $(patsubst %.C, %.o, $(S2DB_CXX_SRC)) $(patsubst %.c, %.o, $(S2D
 
 XCR_EXEC     := $(DESTDIR)$(LIBEXEC)/xalt_configuration_report.x
 XCR_CXX_SRC  := xalt_configuration_report.C epoch.C Json.C
-XCR_C_SRC    := xalt_quotestring.c 
+XCR_C_SRC    := xalt_quotestring.c xalt_fgets_alloc.c
 XCR_OBJS     := $(patsubst %.C, %.o, $(XCR_CXX_SRC)) $(patsubst %.c, %.o, $(XCR_C_SRC)) xalt_syshost.o
 
 XER_EXEC     := $(DESTDIR)$(LIBEXEC)/xalt_extract_record.x
@@ -157,7 +157,7 @@ XER_OBJS     := $(patsubst %.C, %.o, $(XER_CXX_SRC))
 
 XRP_EXEC     := $(DESTDIR)$(LIBEXEC)/xalt_record_pkg
 XRP_C_SRC    := xalt_record_pkg.c transmit.c xalt_c_utils.c xalt_quotestring.c build_uuid.c \
-                zstring.c base64.c xalt_syshost.c xalt_tmpdir.c
+                zstring.c base64.c xalt_fgets_alloc.c xalt_syshost.c xalt_tmpdir.c
 XRP_OBJS     := $(patsubst %.c, %.o, $(XRP_C_SRC))
 
 
@@ -198,7 +198,7 @@ $(TRP_EXEC) : $(TRP_OBJS)
 	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(XRP_EXEC) : $(XRP_OBJS)
-	$(LINK.c) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -L$(DESTDIR)$(LIB64) -o $@ $^ -lz  -l:libuuid.a 
+	$(LINK.c) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -L$(DESTDIR)$(LIB64) -o $@ $^ -lz  -l:libuuid.a
 
 $(XRS_EXEC) : $(XRS_OBJS)
 	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^ -lz -lpthread $(LIBCRYPTO)
@@ -215,10 +215,10 @@ $(XEL_EXEC) : $(XEL_OBJS)
 $(XSL_EXEC) : $(XSL_OBJS)
 	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
-$(XCR_EXEC) : $(XCR_OBJS) 
+$(XCR_EXEC) : $(XCR_OBJS)
 	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
-$(XER_EXEC) : $(XER_OBJS) 
+$(XER_EXEC) : $(XER_OBJS)
 	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(F2DB_EXEC) : $(F2DB_OBJS)
@@ -292,20 +292,20 @@ $(DESTDIR)$(LIB64)/lex.__XALT_host_preload.o: __build__/lex.__XALT_hostL.c xalt_
 $(DESTDIR)$(LIB64)/xalt_quotestring.o: xalt_quotestring.c xalt_quotestring.h
 	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB64)/xalt_syshost.o: $(CURDIR)/__build__/xalt_syshost.c
-	$(COMPILE.c) $(CF_INIT) -o $@ -c $< 
-$(DESTDIR)$(LIB64)/base64.o: base64.c base64.h 
-	$(COMPILE.c) $(CF_INIT) -o $@ -c $< 
-$(DESTDIR)$(LIB64)/xalt_tmpdir.o: xalt_tmpdir.c xalt_tmpdir.h __build__/xalt_config.h 
-	$(COMPILE.c) $(CF_INIT) -o $@ -c $< 
+	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
+$(DESTDIR)$(LIB64)/base64.o: base64.c base64.h
+	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
+$(DESTDIR)$(LIB64)/xalt_tmpdir.o: xalt_tmpdir.c xalt_tmpdir.h __build__/xalt_config.h
+	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB64)/xalt_fgets_alloc.o: xalt_fgets_alloc.c xalt_fgets_alloc.h
 	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB64)/build_uuid.o: build_uuid.c __build__/xalt_config.h xalt_obfuscate.h xalt_utils.h build_uuid.h
 	$(COMPILE.c) -I$(srcdir)/libuuid/src $(CF_INIT) -DSTATE=REGULAR -o $@ -c $<
 $(DESTDIR)$(LIB64)/build_uuid_preload.o: build_uuid.c __build__/xalt_config.h xalt_obfuscate.h xalt_utils.h build_uuid.h
 	$(COMPILE.c)  -I$(srcdir)/libuuid/src $(CF_INIT) -DSTATE=LD_PRELOAD -o $@ -c $<
-$(DESTDIR)$(LIB64)/xalt_initialize.o: xalt_initialize.c xalt_quotestring.h __build__/xalt_config.h 
+$(DESTDIR)$(LIB64)/xalt_initialize.o: xalt_initialize.c xalt_quotestring.h __build__/xalt_config.h
 	$(COMPILE.c) $(CF_INIT) -Wno-unused-variable -DSTATE=REGULAR -DIDX=1 -o $@ -c $<
-$(DESTDIR)$(LIB64)/xalt_initialize_preload.o: xalt_initialize.c xalt_quotestring.h __build__/xalt_config.h 
+$(DESTDIR)$(LIB64)/xalt_initialize_preload.o: xalt_initialize.c xalt_quotestring.h __build__/xalt_config.h
 	$(LINK.c) $(CFLAGS) $(CF_INIT) -Wno-unused-variable -DSTATE=LD_PRELOAD -DIDX=0 -o $@ -c $<
 $(DESTDIR)$(LIB64)/my_hostname_parser.o: $(MY_HOSTNAME_PARSER_SRC)
 	$(COMPILE.c) -c -o $@ $^
@@ -319,23 +319,23 @@ $(DESTDIR)$(LIB)/lex.__XALT_host_32.o: __build__/lex.__XALT_hostR.c xalt_obfusca
 	$(COMPILE.c) -m32 -Wno-unused-function $(CF_INIT) -DSTATE=REGULAR -o $@ -c $<
 $(DESTDIR)$(LIB)/lex.__XALT_host_preload_32.o: __build__/lex.__XALT_hostL.c xalt_obfuscate.h
 	$(COMPILE.c) -m32 -Wno-unused-function $(CF_INIT) -DSTATE=LD_PRELOAD -o $@ -c $<
-$(DESTDIR)$(LIB)/xalt_tmpdir_32.o: xalt_tmpdir.c xalt_tmpdir.h  __build__/xalt_config.h 
-	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $< 
-$(DESTDIR)$(LIB)/base64.o: base64.c base64.h 
-	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $< 
+$(DESTDIR)$(LIB)/xalt_tmpdir_32.o: xalt_tmpdir.c xalt_tmpdir.h  __build__/xalt_config.h
+	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $<
+$(DESTDIR)$(LIB)/base64.o: base64.c base64.h
+	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB)/xalt_quotestring_32.o: xalt_quotestring.c xalt_quotestring.h
 	$(COMPILE.c) -m32  $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB)/xalt_syshost_32.o: $(CURDIR)/__build__/xalt_syshost.c
-	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $< 
+	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB)/build_uuid_32.o: build_uuid.c __build__/xalt_config.h xalt_obfuscate.h xalt_utils.h build_uuid.h
 	$(COMPILE.c) -m32 -I$(srcdir)/libuuid/src $(CF_INIT) -DSTATE=REGULAR    -o $@ -c $<
 $(DESTDIR)$(LIB)/build_uuid_preload_32.o: build_uuid.c __build__/xalt_config.h xalt_obfuscate.h xalt_utils.h build_uuid.h
 	$(COMPILE.c) -m32 -I$(srcdir)/libuuid/src $(CF_INIT) -DSTATE=LD_PRELOAD -o $@ -c $<
 $(DESTDIR)$(LIB)/xalt_fgets_alloc_32.o: xalt_fgets_alloc.c xalt_fgets_alloc.h
 	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $<
-$(DESTDIR)$(LIB)/xalt_initialize_32.o: xalt_initialize.c xalt_quotestring.h __build__/xalt_config.h 
+$(DESTDIR)$(LIB)/xalt_initialize_32.o: xalt_initialize.c xalt_quotestring.h __build__/xalt_config.h
 	$(COMPILE.c) -m32 $(CF_INIT) -DIN_32_BIT_MODE -Wno-unused-variable -DSTATE=REGULAR    -DIDX=1 -I__build__  -o $@ -c $<
-$(DESTDIR)$(LIB)/xalt_initialize_preload_32.o: xalt_initialize.c xalt_quotestring.h __build__/xalt_config.h 
+$(DESTDIR)$(LIB)/xalt_initialize_preload_32.o: xalt_initialize.c xalt_quotestring.h __build__/xalt_config.h
 	$(COMPILE.c) -m32 $(CF_INIT) -DIN_32_BIT_MODE -Wno-unused-variable -DSTATE=LD_PRELOAD -DIDX=0 -I__build__  -o $@ -c $<
 $(DESTDIR)$(LIB)/my_hostname_parser_32.o: $(MY_HOSTNAME_PARSER_SRC)
 	$(COMPILE.c) -m32 -c -o $@ $^
@@ -364,7 +364,7 @@ $(DESTDIR)$(LIB64)/libxalt_init.so: $(DESTDIR)$(LIB64)/xalt_initialize_preload.o
 
 neat:
 	$(RM) *~
-clean: 
+clean:
 	$(RM) *.o
 
 


### PR DESCRIPTION
Both applications:
* xalt_record_pkg; and
* xalt_configuration_report.x

miss a compilation dependency on `xalt_fgets_alloc.c`.

I could only trigger the error when compiling XALT 2 using option
```
--with-syshostConfig=read_file:/etc/my_hostname_file
```

The erros are:

```
gcc -g -O2  -I/home/mydummyuser/xalt/libuuid/src -Wall
-Wno-unused-result   -I__build__ -I/home/mydummyuser/xalt/src       -g
-O2  -I/home/mydummyuser/xalt/libuuid/src -Wall -Wno-unused-result
-L/users/hvictor/bin/xalt/xalt2/xalt/2.6.3/lib64 -o
/users/hvictor/bin/xalt/xalt2/xalt/2.6.3/libexec/xalt_record_pkg
xalt_record_pkg.o transmit.o xalt_c_utils.o xalt_quotestring.o
build_uuid.o zstring.o base64.o xalt_syshost.o xalt_tmpdir.o -lz
-l:libuuid.a
/usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld:
xalt_syshost.o: in function `__XALT_syshost_xalt_1_5':
/home/mydummyuser/xalt/src/__build__/xalt_syshost.c:16: undefined
reference to `__XALT_fgets_alloc_xalt_1_5'
collect2: error: ld returned 1 exit status
makefile:201: recipe for target
'/users/hvictor/bin/xalt/xalt2/xalt/2.6.3/libexec/xalt_record_pkg'
failed
make[1]: ***
[/users/hvictor/bin/xalt/xalt2/xalt/2.6.3/libexec/xalt_record_pkg] Error
1
make[1]: Leaving directory '/home/mydummyuser/xalt/src'
makefile:132: recipe for target 'build_compiled' failed
make: *** [build_compiled] Error 2
```

And
```
g++ -g -O2  -I/home/mydummyuser/xalt/libuuid/src -Wall
-Wno-unused-result  -I__build__ -I/home/mydummyuser/xalt/src -std=c++11
-DHAVE_FILE_PREFIX    -g -O2  -I/home/mydummyuser/xalt/libuuid/src -Wall
-Wno-unused-result  -o
/users/hvictor/bin/xalt/xalt2/xalt/2.6.3/libexec/xalt_configuration_report.x
xalt_configuration_report.o epoch.o Json.o xalt_quotestring.o
xalt_syshost.o
/usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld:
xalt_syshost.o: in function `__XALT_syshost_xalt_1_5':
/home/mydummyuser/xalt/src/__build__/xalt_syshost.c:16: undefined
reference to `__XALT_fgets_alloc_xalt_1_5'
collect2: error: ld returned 1 exit status
makefile:219: recipe for target
'/users/hvictor/bin/xalt/xalt2/xalt/2.6.3/libexec/xalt_configuration_report.x'
failed
make[1]: ***
[/users/hvictor/bin/xalt/xalt2/xalt/2.6.3/libexec/xalt_configuration_report.x]
Error 1
make[1]: Leaving directory '/home/mydummyuser/xalt/src'
makefile:132: recipe for target 'build_compiled' failed
make: *** [build_compiled] Error 2
```