### PR TITLE
replace static XALT_DIR with runtime configurable path

### DIFF
--- a/configure
+++ b/configure
@@ -627,6 +627,7 @@ CURL_STR
 CRYPTO_STR
 XALT_GIT_VERSION
 VERSION
+SUBDIR
 PKGV
 HAVE_DCGM
 HAVE_NVML
@@ -653,7 +654,6 @@ XALT_PRIME_NUMBER
 XALT_TMPDIR
 BIT32
 BAD_INSTALL
-SUBDIR
 PRELOAD_ONLY
 STATIC_LIBS
 MY_HOSTNAME_PARSER
@@ -4650,6 +4650,14 @@ else
 fi
 
 
+ac_fn_c_check_header_mongrel "$LINENO" "syslog.h" "ac_cv_header_syslog_h" "$ac_includes_default"
+if test "x$ac_cv_header_syslog_h" = xyes; then :
+
+else
+  as_fn_error $? "Unable to build XALT without syslog.h. Please install the glibc headers package" "$LINENO" 5
+fi
+
+
 
 
 
@@ -4962,6 +4970,7 @@ else
 fi
 
 fi
+
 
 
 

--- a/configure
+++ b/configure
@@ -653,6 +653,7 @@ XALT_PRIME_NUMBER
 XALT_TMPDIR
 BIT32
 BAD_INSTALL
+SUBDIR
 PRELOAD_ONLY
 STATIC_LIBS
 MY_HOSTNAME_PARSER
@@ -4968,6 +4969,7 @@ fi
 
 VERSION=$(cat $ac_confdir/.version | sed -e 's/-devel//g')
 PKGV=$prefix/xalt/$VERSION
+SUBDIR=xalt/$VERSION
 
 if test $BAD_INSTALL = no; then
    if echo $prefix | grep -i xalt/$VERSION > /dev/null ; then

--- a/configure.ac
+++ b/configure.ac
@@ -377,6 +377,8 @@ AC_CHECK_HEADER(openssl/sha.h,
 
 AC_CHECK_HEADER(gelf.h, [],
                 [AC_MSG_ERROR([Unable to build XALT without gelf.h. Please install the libelf development package])])
+AC_CHECK_HEADER(syslog.h, [],
+                [AC_MSG_ERROR([Unable to build XALT without syslog.h. Please install the glibc headers package])])
 
 
 AC_SUBST(HAVE_WORKING_LIBUUID)
@@ -439,11 +441,13 @@ elif test $XALT_GPU_TRACKING = yes || test $XALT_GPU_TRACKING = "nvml" ; then
 fi
 
 AC_SUBST(PKGV)
+AC_SUBST(SUBDIR)
 AC_SUBST(VERSION)
 AC_SUBST(XALT_GIT_VERSION)
 
 VERSION=$(cat $ac_confdir/.version | sed -e 's/-devel//g')
 PKGV=$prefix/xalt/$VERSION
+SUBDIR=xalt/$VERSION
 
 if test $BAD_INSTALL = no; then
    if echo $prefix | grep -i xalt/$VERSION > /dev/null ; then

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -287,7 +287,7 @@ build_init: $(DESTDIR)$(LIB64)/xalt_quotestring.o     $(DESTDIR)$(LIB64)/xalt_ve
             $(DESTDIR)$(LIB64)/lex.__XALT_path.o      $(DESTDIR)$(LIB64)/lex.__XALT_path_preload.o \
             $(DESTDIR)$(LIB64)/lex.__XALT_host.o      $(DESTDIR)$(LIB64)/lex.__XALT_host_preload.o \
             $(DESTDIR)$(LIB64)/base64.o               $(DESTDIR)$(LIB64)/xalt_tmpdir.o             \
-            $(MY_HOSTNAME_PARSER_OBJ)
+            $(DESTDIR)$(LIB64)/xalt_dir.o             $(MY_HOSTNAME_PARSER_OBJ)
 
 build_init_32bit_no:
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -49,6 +49,7 @@ C_SRC       :=                             \
                jsmn.c             	   \
                transmit.c             	   \
 	       xalt_c_utils.c              \
+               xalt_dir.c                  \
 	       xalt_fgets_alloc.c 	   \
                xalt_initialize.c  	   \
                xalt_record_pkg.c           \
@@ -89,7 +90,7 @@ CXX_SRC     :=                             \
 
 
 UUIDGEN_EXEC := $(DESTDIR)$(BIN)/my_uuidgen
-UUIDGEN_SRC  := my_uuidgen.c build_uuid.c
+UUIDGEN_SRC  := my_uuidgen.c build_uuid.c xalt_dir.c
 UUIDGEN_OBJS := $(patsubst %.c, %.o, $(UUIDGEN_SRC))
 
 TRP_EXEC     := $(DESTDIR)$(LIBEXEC)/test_record_pkg
@@ -105,7 +106,7 @@ XRS_CXX_SRC  := xalt_run_submission.C ConfigParser.C Json.C Options.C Process.C 
                 buildRmapT.C buildUserT.C capture.C extractXALTRecord.C parseJsonStr.C           \
                 translate.C xalt_utils.C epoch.C walkProcessTree.C compute_sha1.C                \
                 parseProcMaps.C pkgRecordTransmit.C
-XRS_C_SRC    := xalt_quotestring.c xalt_fgets_alloc.c jsmn.c  __build__/lex.xalt_env.c transmit.c xalt_c_utils.c \
+XRS_C_SRC    := xalt_quotestring.c xalt_fgets_alloc.c jsmn.c  __build__/lex.xalt_env.c transmit.c xalt_c_utils.c xalt_dir.c \
                 zstring.c base64.c xalt_tmpdir.c  build_uuid.c xalt_syshost.c
 XRS_OBJS     := $(patsubst %.C, %.o, $(XRS_CXX_SRC)) $(patsubst %.c, %.o, $(XRS_C_SRC))
 
@@ -117,7 +118,7 @@ XGM_OBJS     := $(patsubst %.C, %.o, $(XGM_CXX_SRC)) $(patsubst %.c, %.o, $(XGM_
 XGL_EXEC     := $(DESTDIR)$(LIBEXEC)/xalt_generate_linkdata
 XGL_CXX_SRC  := xalt_generate_linkdata.C parseJsonStr.C parseJsonStr.C buildRmapT.C xalt_utils.C     \
                 Json.C parseLDTrace.C capture.C zstring.C  ConfigParser.C epoch.C compute_sha1.C
-XGL_C_SRC    := xalt_fgets_alloc.c  xalt_quotestring.c jsmn.c transmit.c xalt_c_utils.c base64.c     \
+XGL_C_SRC    := xalt_fgets_alloc.c  xalt_quotestring.c jsmn.c transmit.c xalt_c_utils.c base64.c xalt_dir.c    \
                 zstring.c
 XGL_OBJS     := $(patsubst %.C, %.o, $(XGL_CXX_SRC)) $(patsubst %.c, %.o, $(XGL_C_SRC))
 
@@ -148,7 +149,7 @@ S2DB_OBJS    := $(patsubst %.C, %.o, $(S2DB_CXX_SRC)) $(patsubst %.c, %.o, $(S2D
 
 XCR_EXEC     := $(DESTDIR)$(LIBEXEC)/xalt_configuration_report.x
 XCR_CXX_SRC  := xalt_configuration_report.C epoch.C Json.C capture.C
-XCR_C_SRC    := xalt_quotestring.c xalt_fgets_alloc.c
+XCR_C_SRC    := xalt_quotestring.c xalt_fgets_alloc.c xalt_dir.c
 XCR_OBJS     := $(patsubst %.C, %.o, $(XCR_CXX_SRC)) $(patsubst %.c, %.o, $(XCR_C_SRC)) xalt_syshost.o
 
 XER_EXEC     := $(DESTDIR)$(LIBEXEC)/xalt_extract_record.x
@@ -157,7 +158,7 @@ XER_OBJS     := $(patsubst %.C, %.o, $(XER_CXX_SRC))
 
 XRP_EXEC     := $(DESTDIR)$(LIBEXEC)/xalt_record_pkg
 XRP_C_SRC    := xalt_record_pkg.c transmit.c xalt_c_utils.c xalt_quotestring.c build_uuid.c \
-                zstring.c base64.c xalt_fgets_alloc.c xalt_syshost.c xalt_tmpdir.c
+                zstring.c base64.c xalt_fgets_alloc.c xalt_syshost.c xalt_tmpdir.c xalt_dir.c
 XRP_OBJS     := $(patsubst %.c, %.o, $(XRP_C_SRC))
 
 
@@ -294,7 +295,8 @@ build_init_32bit_yes: $(DESTDIR)$(LIB)/xalt_quotestring_32.o $(DESTDIR)$(LIB)/xa
                       $(DESTDIR)$(LIB)/xalt_fgets_alloc_32.o $(DESTDIR)$(LIB)/xalt_initialize_32.o \
                       $(DESTDIR)$(LIB)/lex.__XALT_path_32.o  $(DESTDIR)$(LIB)/libxalt_init.so      \
                       $(DESTDIR)$(LIB)/lex.__XALT_host_32.o  $(DESTDIR)$(LIB)/base64.o             \
-                      $(DESTDIR)$(LIB)/xalt_tmpdir_32.o      $(MY_HOSTNAME_PARSER_OBJ_32)
+                      $(DESTDIR)$(LIB)/xalt_tmpdir_32.o      $(DESTDIR)$(LIB)/xalt_dir_32.o        \
+                      $(MY_HOSTNAME_PARSER_OBJ_32)
 
 
 
@@ -309,6 +311,8 @@ $(DESTDIR)$(LIB64)/lex.__XALT_host_preload.o: __build__/lex.__XALT_hostL.c xalt_
 $(DESTDIR)$(LIB64)/xalt_quotestring.o: xalt_quotestring.c xalt_quotestring.h
 	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB64)/base64.o: base64.c base64.h
+	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
+$(DESTDIR)$(LIB64)/xalt_dir.o: xalt_dir.c xalt_dir.h __build__/xalt_config.h
 	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB64)/xalt_tmpdir.o: xalt_tmpdir.c xalt_tmpdir.h __build__/xalt_config.h
 	$(COMPILE.c) $(CF_INIT) -o $@ -c $<
@@ -336,6 +340,8 @@ $(DESTDIR)$(LIB)/xalt_vendor_note_32.o: xalt_vendor_note.c xalt_vendor_note.h
 	$(COMPILE.c) -m32 $(CF_INIT) -Wno-int-to-pointer-cast -o $@ -c $<
 $(DESTDIR)$(LIB)/xalt_tmpdir_32.o: xalt_tmpdir.c xalt_tmpdir.h  __build__/xalt_config.h
 	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $<
+$(DESTDIR)$(LIB)/xalt_dir_32.o: xalt_dir.c xalt_dir.h  __build__/xalt_config.h
+	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB)/base64.o: base64.c base64.h
 	$(COMPILE.c) -m32 $(CF_INIT) -o $@ -c $<
 $(DESTDIR)$(LIB)/xalt_quotestring_32.o: xalt_quotestring.c xalt_quotestring.h
@@ -356,6 +362,7 @@ $(DESTDIR)$(LIB)/libxalt_init.so: $(DESTDIR)$(LIB)/xalt_initialize_preload_32.o 
                                   $(DESTDIR)$(LIB)/xalt_tmpdir_32.o             \
                                   $(DESTDIR)$(LIB)/xalt_vendor_note_32.o        \
                                   $(DESTDIR)$(LIB)/base64.o                     \
+                                  $(DESTDIR)$(LIB)/xalt_dir_32.o                \
                                   $(MY_HOSTNAME_PARSER_OBJ_32)
 	$(LINK.c) -m32 $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) $(LDFLAGS) -L$(DESTDIR)$(LIB) -o $@  $^
 
@@ -367,6 +374,7 @@ $(DESTDIR)$(LIB64)/libxalt_init.so: $(DESTDIR)$(LIB64)/xalt_initialize_preload.o
                                     $(DESTDIR)$(LIB64)/base64.o                  \
                                     $(DESTDIR)$(LIB64)/xalt_tmpdir.o             \
                                     $(DESTDIR)$(LIB64)/xalt_vendor_note.o        \
+                                    $(DESTDIR)$(LIB64)/xalt_dir.o                \
                                     $(MY_HOSTNAME_PARSER_OBJ)                    \
                                     $(DESTDIR)$(LIB64)/xalt_fgets_alloc.o
 	$(LINK.c) $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) $(LDFLAGS) -L$(DESTDIR)$(LIB64) -o $@  $^ $(LIBDCGM) $(LIBNVML)

--- a/src/build_uuid.c
+++ b/src/build_uuid.c
@@ -6,6 +6,7 @@
 #include "build_uuid.h"
 #include "xalt_fgets_alloc.h"
 #include "xalt_config.h"
+#include "xalt_dir.h"
 #include <uuid/uuid.h>
 #define BAD_UUID "deadbeaf-dead-beef-1111-deadbeef1111"
 void build_uuid(char * my_uuid_str)

--- a/src/build_uuid.c
+++ b/src/build_uuid.c
@@ -19,7 +19,7 @@ void build_uuid(char * my_uuid_str)
   handle = dlopen ("libuuid.so.1", RTLD_LAZY);
   if (!handle) 
     {
-      handle = dlopen (XALT_DIR "lib64/libuuid.so", RTLD_LAZY);
+      handle = dlopen (xalt_dir("lib64/libuuid.so"), RTLD_LAZY);
       if (!handle) 
         {
           fputs (dlerror(), stderr);

--- a/src/compute_sha1.C
+++ b/src/compute_sha1.C
@@ -1,5 +1,6 @@
 #include "xalt_config.h"
 #include "compute_sha1.h"
+#include "xalt_dir.h"
 #include <fcntl.h>
 #include <openssl/sha.h>
 #include <pthread.h>

--- a/src/compute_sha1.C
+++ b/src/compute_sha1.C
@@ -45,7 +45,7 @@ void compute_sha1(std::string& fn, std::string& sha1_str)
       void * handle = dlopen("libcrypto.so", RTLD_LAZY);
       if (!handle)
         {
-          handle = dlopen (XALT_DIR "lib64/libcrypto.so", RTLD_LAZY);
+          handle = dlopen (xalt_dir("lib64/libcrypto.so"), RTLD_LAZY);
           if (!handle) 
             {
               fputs(dlerror(), stderr);

--- a/src/xalt_config.h.in
+++ b/src/xalt_config.h.in
@@ -1,6 +1,10 @@
 #ifndef XALT_CONFIG_H
 #define XALT_CONFIG_H
 
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+
 /* Remember that AC_DEFINE() end up in xalt_header.h.in
  * AC_SUBST() end up in xalt_config.h.in
  */
@@ -22,7 +26,7 @@
 #define XALT_CMDLINE_RECORD        "@XALT_CMDLINE_RECORD@"
 #define XALT_COMPUTE_SHA1          "@COMPUTE_SHA1SUM@"
 #define XALT_CONFIG_PY             "@XALT_CONFIG_PY@"
-#define XALT_DIR                   "@prefix@/xalt/xalt/"
+#define XALT_DEFAULT_DIR           "@prefix@/@SUBDIR@"
 #define XALT_ETC_DIR               "@ETC_DIR@"
 #define XALT_FILE_PREFIX           "@XALT_FILE_PREFIX@"
 #define XALT_FUNCTION_TRACKING     "@XALT_FUNCTION_TRACKING@"
@@ -39,5 +43,21 @@
 #define XALT_SYSTEM_PATH           "@SYSTEM_PATH@"
 #define XALT_TMPDIR                "@XALT_TMPDIR@"
 #define XALT_VERSION               "@VERSION@"
+
+static const char* xalt_dir(const char* file) {
+  const char* dir = getenv("XALT_DIR") ? getenv("XALT_DIR") : XALT_DEFAULT_DIR;
+
+  if (!file) {
+    return dir;
+  }
+  else {
+    char *joined;
+    int ret = asprintf(&joined, "%s/%s", dir, file);
+    if (ret > 0)
+      return joined;
+    else
+      return file;
+  }
+}
 
 #endif /* XALT_CONFIG_H */

--- a/src/xalt_config.h.in
+++ b/src/xalt_config.h.in
@@ -1,14 +1,9 @@
 #ifndef XALT_CONFIG_H
 #define XALT_CONFIG_H
 
-#define _GNU_SOURCE
-#include <stdio.h>
-#include <stdlib.h>
-
 /* Remember that AC_DEFINE() end up in xalt_header.h.in
  * AC_SUBST() end up in xalt_config.h.in
  */
-
 
 #define BAD_INSTALL                "@BAD_INSTALL@"
 #define CRYPTO_STR                 "@CRYPTO_STR@"
@@ -43,21 +38,5 @@
 #define XALT_SYSTEM_PATH           "@SYSTEM_PATH@"
 #define XALT_TMPDIR                "@XALT_TMPDIR@"
 #define XALT_VERSION               "@VERSION@"
-
-static const char* xalt_dir(const char* file) {
-  const char* dir = getenv("XALT_DIR") ? getenv("XALT_DIR") : XALT_DEFAULT_DIR;
-
-  if (!file) {
-    return dir;
-  }
-  else {
-    char *joined;
-    int ret = asprintf(&joined, "%s/%s", dir, file);
-    if (ret > 0)
-      return joined;
-    else
-      return file;
-  }
-}
 
 #endif /* XALT_CONFIG_H */

--- a/src/xalt_configuration_report.C
+++ b/src/xalt_configuration_report.C
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
 
 
   Vstring     resultA;
-  std::string cmd     = XALT_DIR "/bin/xalt_print_os";
+  std::string cmd     = xalt_dir("bin/xalt_print_os");
   capture(cmd, resultA);
   std::string current_os_descript = resultA[0];
 
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
       json.add("XALT_PRIME_NUMBER",             XALT_PRIME_NUMBER);
       json.add("XALT_COMPUTE_SHA1",             computeSHA1);
       json.add("XALT_ETC_DIR",                  xalt_etc_dir);
-      json.add("XALT_DIR",                      XALT_DIR);
+      json.add("XALT_DIR",                      xalt_dir(NULL));
       json.add("BAD_INSTALL",                   BAD_INSTALL);
       json.add("XALT_CONFIG_PY",                XALT_CONFIG_PY);
       json.add("XALT_CMDLINE_RECORD",           cmdline_record);
@@ -232,7 +232,7 @@ int main(int argc, char* argv[])
     std::cout << "XALT_LOGGING_URL:                " << log_url                      << "\n";
   std::cout << "XALT_COMPUTE_SHA1 on libraries:  " << computeSHA1                    << "\n";
   std::cout << "XALT_ETC_DIR:                    " << xalt_etc_dir                   << "\n";
-  std::cout << "XALT_DIR:                        " << XALT_DIR                       << "\n";
+  std::cout << "XALT_DIR:                        " << xalt_dir(NULL)                 << "\n";
   std::cout << "BAD_INSTALL:                     " << BAD_INSTALL                    << "\n";
   std::cout << "XALT_CONFIG_PY:                  " << XALT_CONFIG_PY                 << "\n";
   std::cout << "XALT_MPI_TRACKING:               " << xalt_mpi_tracking              << "\n";

--- a/src/xalt_configuration_report.C
+++ b/src/xalt_configuration_report.C
@@ -4,6 +4,7 @@
 #include "capture.h"
 #include "xalt_syshost.h"
 #include "xalt_config.h"
+#include "xalt_dir.h"
 #include "xalt_regex.h"
 #include "xalt_version.h"
 #include "xalt_interval.h"

--- a/src/xalt_dir.c
+++ b/src/xalt_dir.c
@@ -1,0 +1,32 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <syslog.h>
+#include <unistd.h>
+#include "xalt_config.h"
+
+const char* xalt_dir(const char* file) {
+  const char* dir = getenv("XALT_DIR") ? getenv("XALT_DIR") : XALT_DEFAULT_DIR;
+
+  if (!file) {
+    return dir;
+  }
+  else {
+    char *joined;
+    int ret = asprintf(&joined, "%s/%s", dir, file);
+    if (ret > 0) {
+      if (access(joined, F_OK) != 0) {
+        syslog(LOG_WARNING, "XALT unable to access '%s'", joined);
+      }
+
+      /* this will leak memory if the caller does not free() the string */
+      return joined;
+    }
+    else {
+      return file;
+    }
+  }
+}

--- a/src/xalt_dir.h
+++ b/src/xalt_dir.h
@@ -1,0 +1,16 @@
+#ifndef XALT_DIR_H
+#define XALT_DIR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  const char* xalt_dir(const char* file);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //XALT_DIR_H
+
+

--- a/src/xalt_initialize.c
+++ b/src/xalt_initialize.c
@@ -577,7 +577,7 @@ void myinit(int argc, char **argv)
 
 	  if ( ! have_uuid )
 	    {
-	      capture( XALT_DIR "/bin/my_uuidgen", buffer, BUFSZ);
+	      capture(xalt_dir("bin/my_uuidgen"), buffer, BUFSZ);
 	      strncpy(&uuid_str[0], buffer, 36);
 	      uuid_str[36] = '\0';
 	      have_uuid = 1;
@@ -673,7 +673,7 @@ void myinit(int argc, char **argv)
     {
       if ( ! have_uuid )
 	{
-	  capture( XALT_DIR "/bin/my_uuidgen", buffer, BUFSZ);
+	  capture(xalt_dir("bin/my_uuidgen"), buffer, BUFSZ);
 	  strncpy(&uuid_str[0], buffer, 36);
 	  uuid_str[36] = '\0';
 	  have_uuid = 1;
@@ -687,7 +687,7 @@ void myinit(int argc, char **argv)
   sprintf(fullDateStr,"%s_%d",dateStr, (int) (frac_time*10000.0));
 
   setenv("XALT_DATE_TIME",fullDateStr,1);
-  setenv("XALT_DIR",XALT_DIR,1);
+  setenv("XALT_DIR",xalt_dir(NULL),1);
 
   pid  = getpid();
   ppid = getppid();
@@ -739,7 +739,7 @@ void myinit(int argc, char **argv)
     {
       char uuid_option_str[100];
 
-      const char * run_submission = XALT_DIR "/libexec/xalt_run_submission";
+      const char * run_submission = xalt_dir("libexec/xalt_run_submission");
       int runable = access(run_submission, X_OK);
 
       if (runable == -1)
@@ -1080,7 +1080,7 @@ void myfini()
 	DEBUG0(my_stderr, "    -> XALT_SAMPLING = \"no\" All programs tracked!\n");
     }
 
-  const char * run_submission = XALT_DIR "/libexec/xalt_run_submission";
+  const char * run_submission = xalt_dir("libexec/xalt_run_submission");
   int runable = (run_submission_exists == 1) ? 1 : access(run_submission, X_OK);
   if (runable == -1)
     {

--- a/src/xalt_initialize.c
+++ b/src/xalt_initialize.c
@@ -50,6 +50,7 @@
 #include "xalt_quotestring.h"
 #include "xalt_header.h"
 #include "xalt_config.h"
+#include "xalt_dir.h"
 #include "xalt_fgets_alloc.h"
 #include "xalt_path_parser.h"
 #include "xalt_hostname_parser.h"


### PR DESCRIPTION
Based on the discussion in #25, this is a proposal to replace the static XALT_DIR path with a runtime configurable path.  The runtime configurable path uses the value of the `XALT_DIR` environment variable, or if not set defaults to the previous static value.

The XALT environment module should set `XALT_DIR` to its install location.  If XALT is updated, then the new version would reset `XALT_DIR` to the new location.  Binaries built with the older XALT would then pickup the new location of the C++ utility programs (assuming they were built with a version that had this change - otherwise the `xalt/xalt` symlink will need to stick around for a while.)

I wrote this up quickly and tried to be as minimally invasive as possible to be a basis for further discussion.  A higher quality rewrite may be necessary.