### PR TITLE
Fix empty function name when linking with ld.gold

### DIFF
--- a/src/linker/parseLDTrace.C
+++ b/src/linker/parseLDTrace.C
@@ -100,7 +100,7 @@ void readFunctionList(const char* fn, SET_t** funcSet)
 
       start += len_needle;
 
-      if (*start == '`')
+      if (*start == '`' || *start == '\'')
         start++;
       char*  p   = strchr(start,'\'');
       if (p)


### PR DESCRIPTION
xalt checks for a function name from a backtick to a quote in the ``undefined reference to `func_name'`` message returned by the linker. 

The gold linker uses a quote instead of a backtick at the beginning of the function name (`undefined reference to 'func_name'`). This results in an empty function name in the xalt record when using function tracking with the gold linker.