### PR TITLE
Rename capture function to something less likely to have collisions

### DIFF
--- a/src/util/buildXALTRecordT.c
+++ b/src/util/buildXALTRecordT.c
@@ -117,7 +117,7 @@ bool extractXALTRecordString(const char* exec_path, char** watermark)
   
   utstring_printf(cmd, "LD_PRELOAD= XALT_EXECUTABLE_TRACKING=no PATH=" XALT_SYSTEM_PATH
                        " objdump -s -j .xalt \"%s\" 2> /dev/null", execQ);
-  capture(utstring_body(cmd), &resultA);
+  xalt_capture(utstring_body(cmd), &resultA);
   utstring_free(cmd);
   
   my_free(execQ, len*3*sizeof(char));

--- a/src/util/capture.c
+++ b/src/util/capture.c
@@ -2,7 +2,7 @@
 #include "utarray.h"
 #define DATA_SIZE 1024
 
-void capture(const char* cmdline, UT_array** p_resultA)
+void xalt_capture(const char* cmdline, UT_array** p_resultA)
 {
   UT_array* resultA;
   FILE* fp;

--- a/src/util/capture.h
+++ b/src/util/capture.h
@@ -6,7 +6,7 @@ extern "C"
 #endif
 
 #include "utarray.h"
-void capture(const char* cmd, UT_array** p_resultA);
+void xalt_capture(const char* cmd, UT_array** p_resultA);
 
 #ifdef __cplusplus
 }

--- a/src/util/xalt_configuration_report.C
+++ b/src/util/xalt_configuration_report.C
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
   char* fn = xalt_dir("bin/xalt_print_os");
   cmd.append(fn);
   free(fn);
-  capture(cmd.c_str(), &resultA);
+  xalt_capture(cmd.c_str(), &resultA);
   char **pp = NULL;
   pp = (char**) utarray_next(resultA, pp);
   std::string current_os_descript = *pp;


### PR DESCRIPTION
We are seeing a segfault when XAlt is loaded and the user runs R and loads the tidyverse library. This appears to be caused by a conflict with the capture function. This PR renames the "capture" function to "xalt_capture" so collisions with other functions with that name are less likely.