### PR TITLE
Don't attempt to write to nonexistent file with tracing off

### DIFF
--- a/src/util/transmit.c
+++ b/src/util/transmit.c
@@ -77,8 +77,11 @@ void transmit(const char* transmission, const char* jsonStr, const char* kind, c
       asprintf(&fn, "%s%s",resultDir, resultFn);
 
       FILE* fp = fopen(tmpFn,"w");
-      if (fp == NULL && xalt_tracing)
-        fprintf(my_stderr,"    Unable to open: %s -> No XALT output\n", fn);
+      if (fp == NULL)
+        {
+          if (xalt_tracing)
+            fprintf(my_stderr,"    Unable to open: %s -> No XALT output\n", fn);
+        }
       else
         {
           fprintf(fp, "%s\n", jsonStr);


### PR DESCRIPTION
If fopen fails in xalt_generate_linkdata and tracing is off, control falls through and the write is attempted which causes a segfault. Fix is to not try the write whether or not tracing is on.
