### PR TITLE
Missing comma in example Lmod modulefile

### DIFF
--- a/docs/source/050_install_and_test.rst
+++ b/docs/source/050_install_and_test.rst
@@ -97,7 +97,7 @@ package.  The first one is a Lua modulefile that can be used with Lmod::
   local bin   = pathJoin(base,"bin")
 
   prepend_path{"PATH",          bin, priority="100"}
-  prepend_path("XALT_DIR"       base)
+  prepend_path("XALT_DIR",      base)
   prepend_path("LD_PRELOAD",    pathJoin(base,"$LIB/libxalt_init.so"))
   prepend_path("COMPILER_PATH", bin)
 


### PR DESCRIPTION
The documentation gives an example of an Lmod modulefile for Xalt at the bottom of [this page](https://xalt.readthedocs.io/en/latest/050_install_and_test.html), but that example is missing a comma in one of its function calls.